### PR TITLE
make modal fixed so it can be seen when scrolling

### DIFF
--- a/src/material-elements/material-popup/material-popup.scss
+++ b/src/material-elements/material-popup/material-popup.scss
@@ -26,7 +26,7 @@ material-popup {
   /** POPUP **/
   .popup {
     z-index: 100;
-    position: absolute;
+    position: fixed;
     left: 0;
     top: 25%;
     right: 0;


### PR DESCRIPTION
My users cannot see the very important modal when they have scrolled down the page.